### PR TITLE
Fix marketing page not appearing due to caching

### DIFF
--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'fieldpro-v2';
+// Bump the cache name to ensure updated pages are fetched
+const CACHE_NAME = 'fieldpro-v3';
 const FILES_TO_CACHE = [
   '/',
   '/index.html',
@@ -9,12 +10,33 @@ const FILES_TO_CACHE = [
   '/js/login.js',
   '/js/dashboard.js'
 ];
+// Pre-cache static assets
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(FILES_TO_CACHE))
   );
 });
+
+// Clean up old caches when a new service worker activates
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+});
+
+// Use a network-first strategy for navigation requests so updated
+// pages like index.html are fetched before falling back to cache.
 self.addEventListener('fetch', event => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(event.request))
+    );
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then(response => response || fetch(event.request))
   );


### PR DESCRIPTION
## Summary
- update service worker cache name and cleanup strategy
- use a network-first strategy for HTML navigation

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6840daf35678832f93f7a1a90886ef5f